### PR TITLE
Change rgl.* to *3d

### DIFF
--- a/R/mully_visualization.R
+++ b/R/mully_visualization.R
@@ -162,8 +162,8 @@ plot3d <- function(g, layers = TRUE,
   if(length(V(g))==0){
     stop("This mully Graph has no nodes.")
   }
-  rgl.open()
-  rgl.bg(
+  open3d()
+  bg3d(
     sphere = TRUE,
     color = c("white", "blue"),
     lit = FALSE,
@@ -272,7 +272,7 @@ plot3d <- function(g, layers = TRUE,
       else
         coord = as.matrix(layout1[temp:(temp + nNodes - 1), ])
       plane = suppressWarnings(get3DPlane(coord, dim(g$layers)[1],nNodes))
-      rgl.planes(
+      planes3d(
         0,
         b = plane[2],
         0,


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to mully. 
I will be deprecating a number of rgl.* function calls.  You can read 
about the issues here:

   https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes in the attached patches.

Duncan Murdoch